### PR TITLE
Add page builder integrations for Elementor, Divi, and Avada

### DIFF
--- a/explorexr/admin/js/browse-models.js
+++ b/explorexr/admin/js/browse-models.js
@@ -109,16 +109,19 @@ jQuery(document).ready(function($) {
             });
         }
     });
-    // Model search functionality
+    // Model search functionality — supports title text and exact/partial model ID
     $('#model-search').on('input', function() {
-        const searchTerm = $(this).val().toLowerCase();
-        
+        const searchTerm = $(this).val().toLowerCase().trim();
+
         // Search through all model cards
         $('.explorexr-model-card').each(function() {
-            const modelTitle = $(this).data('title').toLowerCase();
-            
-            // Show/hide based on search match
-            if (modelTitle.includes(searchTerm)) {
+            const modelTitle = String($(this).data('title') || '').toLowerCase();
+            const modelId    = String($(this).data('id')    || '');
+
+            // Match by title substring OR by model ID (partial match allowed)
+            const matches = modelTitle.includes(searchTerm) || modelId.includes(searchTerm);
+
+            if (matches) {
                 $(this).show();
             } else {
                 $(this).hide();

--- a/explorexr/admin/models/modern-model-browser.php
+++ b/explorexr/admin/models/modern-model-browser.php
@@ -72,7 +72,7 @@ function explorexr_modern_model_browser_page() {
                     
                     <div class="explorexr-form-group" style="flex: 1; min-width: 200px;">
                         <label for="search">Search Models</label>
-                        <input type="text" id="search" name="search" value="<?php echo esc_attr($search_term); ?>" placeholder="Search by title..." class="regular-text">
+                        <input type="text" id="search" name="search" value="<?php echo esc_attr($search_term); ?>" placeholder="Search by title or ID..." class="regular-text">
                     </div>
                     
                     <div class="explorexr-form-group" style="width: 150px;">
@@ -131,9 +131,14 @@ function explorexr_modern_model_browser_page() {
             'orderby' => ($sort_by === 'title') ? 'title' : 'date'
         );
         
-        // Add search if provided
+        // Add search if provided — numeric-only terms are treated as a model ID lookup
         if (!empty($search_term)) {
-            $args['s'] = $search_term;
+            if (ctype_digit($search_term)) {
+                // Exact post ID match
+                $args['p'] = intval($search_term);
+            } else {
+                $args['s'] = $search_term;
+            }
         }
         
         $models = new WP_Query($args);

--- a/explorexr/admin/pages/browse-models-page.php
+++ b/explorexr/admin/pages/browse-models-page.php
@@ -105,7 +105,7 @@ function explorexr_browse_models_page() {
                 <?php else : ?>
                     <div class="explorexr-filter-bar">
                         <div class="explorexr-search-box">
-                            <input type="text" id="model-search" placeholder="Search models...">
+                            <input type="text" id="model-search" placeholder="Search by title or ID...">
                             <button type="button" class="button"><span class="dashicons dashicons-search"></span></button>
                         </div>
                         <div class="explorexr-sort-options">
@@ -128,7 +128,7 @@ function explorexr_browse_models_page() {
                             $ar_enabled = get_post_meta($model->ID, '_explorexr_model_ar', true) ?: '';
                             $shortcode = '[explorexr_model id="' . $model->ID . '"]';
                         ?>
-                            <div class="explorexr-model-card" data-title="<?php echo esc_attr($model->post_title); ?>" data-date="<?php echo esc_attr($model->post_date); ?>">
+                            <div class="explorexr-model-card" data-title="<?php echo esc_attr($model->post_title); ?>" data-date="<?php echo esc_attr($model->post_date); ?>" data-id="<?php echo esc_attr($model->ID); ?>">
                                 <div class="explorexr-model-preview">
                                     <?php if (!empty($model_file)) : ?>                                        <model-viewer src="<?php echo esc_url($model_file); ?>"
                                             <?php if (!empty($poster)) : ?>poster="<?php echo esc_url($poster); ?>"<?php endif; ?>

--- a/explorexr/explorexr.php
+++ b/explorexr/explorexr.php
@@ -115,9 +115,11 @@ function explorexr_free_load_includes() {
         require_once EXPLOREXR_PLUGIN_DIR . 'admin/ajax/ajax-handlers.php';
     }
 
-    // Integrations removed from Free version
-    // Free version only supports shortcode usage
-    // For WooCommerce and Elementor integration, upgrade to Premium
+    // Page-builder integrations (Elementor, Divi, Avada Fusion Builder).
+    // Each integration file checks for the corresponding builder before loading.
+    if ( file_exists( EXPLOREXR_PLUGIN_DIR . 'includes/integrations/index.php' ) ) {
+        require_once EXPLOREXR_PLUGIN_DIR . 'includes/integrations/index.php';
+    }
 
     // Security (basic level for free version)
     if (file_exists(EXPLOREXR_PLUGIN_DIR . 'includes/security/file-upload-sanitizer.php')) {

--- a/explorexr/includes/integrations/avada/class-fusion-element.php
+++ b/explorexr/includes/integrations/avada/class-fusion-element.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * ExploreXR – Avada Fusion Builder Element
+ *
+ * Registers a custom Fusion Builder element (Avada's page builder) so
+ * editors can drag "3D Model (ExploreXR)" into any layout and see the live
+ * 3D model in the Fusion Builder preview.
+ *
+ * Fusion Builder renders shortcodes server-side and streams the HTML back to
+ * the browser preview, so the model-viewer element renders normally.
+ *
+ * @package ExploreXR
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Bootstrap: hook into Fusion Builder's element registration action.
+ */
+add_action( 'fusion_builder_before_init', 'explorexr_register_fusion_element' );
+
+function explorexr_register_fusion_element() {
+    // Guard: Fusion_Builder_Element base class must exist.
+    if ( ! class_exists( 'Fusion_Builder_Element' ) ) {
+        return;
+    }
+
+    /**
+     * Class ExploreXR_Fusion_Element
+     *
+     * A Fusion Builder element that wraps the [explorexr_model] shortcode.
+     */
+    class ExploreXR_Fusion_Element extends Fusion_Builder_Element { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+
+        /**
+         * Element metadata.
+         */
+        public function __construct() {
+            parent::__construct(
+                'explorexr_3d_model',  // Shortcode tag used by Fusion Builder internally.
+                esc_html__( '3D Model (ExploreXR)', 'explorexr' ),
+                EXPLOREXR_PLUGIN_URL . 'assets/img/icons/Icon.png', // Element icon.
+                [],   // Default attributes (see get_element_defaults).
+                [],   // Additional args.
+                'explorexr_fusion_element_render' // Render callback function.
+            );
+        }
+
+        /**
+         * Return default attribute values.
+         *
+         * @return array
+         */
+        public function get_element_defaults() {
+            return [
+                'model_id'        => '0',
+                'model_id_manual' => '',
+            ];
+        }
+
+        /**
+         * Return the element's UI options for the Fusion Builder panel.
+         *
+         * @return array
+         */
+        public function get_options() {
+            // Build select options from all published ExploreXR models.
+            $model_posts   = get_posts( [
+                'post_type'      => 'explorexr_model',
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'orderby'        => 'title',
+                'order'          => 'ASC',
+            ] );
+
+            $model_choices = [ '0' => esc_html__( '— Select a model —', 'explorexr' ) ];
+            foreach ( $model_posts as $model ) {
+                $model_choices[ $model->ID ] = sprintf( '%s (ID: %d)', $model->post_title, $model->ID );
+            }
+
+            return [
+                [
+                    'type'        => 'select',
+                    'heading'     => esc_html__( '3D Model', 'explorexr' ),
+                    'description' => esc_html__( 'Choose the 3D model to display.', 'explorexr' ),
+                    'param_name'  => 'model_id',
+                    'value'       => $model_choices,
+                    'default'     => '0',
+                ],
+                [
+                    'type'        => 'textfield',
+                    'heading'     => esc_html__( 'Or enter Model ID manually', 'explorexr' ),
+                    'description' => esc_html__( 'Overrides the dropdown above. Find the ID in ExploreXR → Browse Models.', 'explorexr' ),
+                    'param_name'  => 'model_id_manual',
+                    'value'       => '',
+                ],
+            ];
+        }
+    }
+
+    new ExploreXR_Fusion_Element(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+}
+
+/**
+ * Render callback for the Fusion Builder element.
+ *
+ * @param array  $args    Element attributes.
+ * @param string $content Inner content (unused for this element).
+ * @return string Rendered HTML.
+ */
+function explorexr_fusion_element_render( $args, $content = '' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+    $model_id = ! empty( $args['model_id_manual'] ) && ctype_digit( trim( $args['model_id_manual'] ) )
+        ? intval( $args['model_id_manual'] )
+        : intval( $args['model_id'] ?? 0 );
+
+    if ( ! $model_id ) {
+        return '<p style="padding:20px;background:#f0f0f0;text-align:center;">'
+             . esc_html__( 'ExploreXR: Please select a 3D model in the element settings.', 'explorexr' )
+             . '</p>';
+    }
+
+    $post = get_post( $model_id );
+    if ( ! $post || $post->post_type !== 'explorexr_model' || $post->post_status !== 'publish' ) {
+        return '<p style="padding:20px;background:#f0f0f0;text-align:center;">'
+             . sprintf(
+                 /* translators: %d: model ID */
+                 esc_html__( 'ExploreXR: Model ID %d not found or not published.', 'explorexr' ),
+                 $model_id
+             )
+             . '</p>';
+    }
+
+    return do_shortcode( '[explorexr_model id="' . $model_id . '"]' );
+}

--- a/explorexr/includes/integrations/divi/class-divi-module.php
+++ b/explorexr/includes/integrations/divi/class-divi-module.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * ExploreXR – Divi Builder Module
+ *
+ * Registers a custom Divi Builder module so editors can search for
+ * "3D Model" in the Divi module list, pick a model from a dropdown and
+ * see it rendered live in the Divi Visual Builder.
+ *
+ * Divi Builder renders shortcodes in its frontend Visual Builder preview,
+ * so the model-viewer custom element works without any extra workaround.
+ *
+ * @package ExploreXR
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Bootstrap: hook into Divi's module init action.
+ */
+add_action( 'et_builder_ready', 'explorexr_register_divi_module' );
+
+function explorexr_register_divi_module() {
+    // Guard: only load if ET_Builder_Module exists (Divi / Extra / Divi Builder plugin).
+    if ( ! class_exists( 'ET_Builder_Module' ) ) {
+        return;
+    }
+
+    /**
+     * Class ExploreXR_Divi_Module
+     *
+     * A Divi Builder module that wraps the [explorexr_model] shortcode.
+     */
+    class ExploreXR_Divi_Module extends ET_Builder_Module { // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+
+        /** @var string Unique module slug. */
+        public $slug       = 'explorexr_3d_model';
+
+        /** @var string Visual Builder render method. */
+        public $vb_support = 'on';
+
+        /**
+         * Module metadata.
+         */
+        public function init() {
+            $this->name             = esc_html__( '3D Model (ExploreXR)', 'explorexr' );
+            $this->icon_path        = EXPLOREXR_PLUGIN_DIR . 'assets/img/icons/Icon.png';
+            $this->main_css_element = '%%order_class%%';
+        }
+
+        /**
+         * Module fields (controls shown in the Divi editor sidebar).
+         *
+         * @return array
+         */
+        public function get_fields() {
+            // Build select options from all published ExploreXR models.
+            $model_posts   = get_posts( [
+                'post_type'      => 'explorexr_model',
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'orderby'        => 'title',
+                'order'          => 'ASC',
+            ] );
+
+            $model_options = [ '0' => esc_html__( '— Select a model —', 'explorexr' ) ];
+            foreach ( $model_posts as $model ) {
+                $model_options[ $model->ID ] = sprintf( '%s (ID: %d)', $model->post_title, $model->ID );
+            }
+
+            return [
+                'model_id' => [
+                    'label'           => esc_html__( '3D Model', 'explorexr' ),
+                    'type'            => 'select',
+                    'option_category' => 'basic_option',
+                    'options'         => $model_options,
+                    'default'         => '0',
+                    'description'     => esc_html__( 'Choose the 3D model to display. Manage models under ExploreXR → Browse Models.', 'explorexr' ),
+                ],
+                'model_id_manual' => [
+                    'label'           => esc_html__( 'Or enter Model ID manually', 'explorexr' ),
+                    'type'            => 'text',
+                    'option_category' => 'basic_option',
+                    'default'         => '',
+                    'description'     => esc_html__( 'Overrides the dropdown. Find the ID in ExploreXR → Browse Models.', 'explorexr' ),
+                ],
+            ];
+        }
+
+        /**
+         * Render the module's HTML output.
+         *
+         * @param array  $attrs   Module attributes.
+         * @param string $content Module inner content (unused).
+         * @param string $render_slug The module slug being rendered.
+         * @return string HTML output.
+         */
+        public function render( $attrs, $content, $render_slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+            $model_id = ! empty( $this->props['model_id_manual'] ) && ctype_digit( trim( $this->props['model_id_manual'] ) )
+                ? intval( $this->props['model_id_manual'] )
+                : intval( $this->props['model_id'] ?? 0 );
+
+            if ( ! $model_id ) {
+                return '<p style="padding:20px;background:#f0f0f0;text-align:center;">'
+                     . esc_html__( 'ExploreXR: Please select a 3D model in the module settings.', 'explorexr' )
+                     . '</p>';
+            }
+
+            // Verify the post.
+            $post = get_post( $model_id );
+            if ( ! $post || $post->post_type !== 'explorexr_model' || $post->post_status !== 'publish' ) {
+                return '<p style="padding:20px;background:#f0f0f0;text-align:center;">'
+                     . sprintf(
+                         /* translators: %d: model ID */
+                         esc_html__( 'ExploreXR: Model ID %d not found or not published.', 'explorexr' ),
+                         $model_id
+                     )
+                     . '</p>';
+            }
+
+            return do_shortcode( '[explorexr_model id="' . $model_id . '"]' );
+        }
+    }
+
+    new ExploreXR_Divi_Module(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+}

--- a/explorexr/includes/integrations/elementor/class-elementor-widget-inner.php
+++ b/explorexr/includes/integrations/elementor/class-elementor-widget-inner.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * ExploreXR – Elementor Widget (inner class definition)
+ *
+ * @package ExploreXR
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+namespace ExploreXR\Integrations\Elementor;
+
+use Elementor\Controls_Manager;
+use Elementor\Widget_Base;
+
+/**
+ * Class Widget_3D_Model
+ *
+ * Elementor widget that embeds a 3D model using the ExploreXR shortcode.
+ * The model renders live in Elementor's preview iframe just like it does on
+ * the published page.
+ */
+class Widget_3D_Model extends Widget_Base {
+
+    /* ------------------------------------------------------------------ */
+    /*  Identity                                                            */
+    /* ------------------------------------------------------------------ */
+
+    public function get_name() {
+        return 'explorexr_3d_model';
+    }
+
+    public function get_title() {
+        return esc_html__( '3D Model (ExploreXR)', 'explorexr' );
+    }
+
+    public function get_icon() {
+        return 'eicon-3d-box';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    public function get_keywords() {
+        return [ '3d', 'model', 'glb', 'gltf', 'ar', 'explorexr', 'xr' ];
+    }
+
+    /**
+     * Declare which registered script handles must be present in the page
+     * when this widget is rendered.  Elementor will ensure these are loaded
+     * in both the frontend and the editor preview iframe.
+     */
+    public function get_script_depends() {
+        return [
+            'model-viewer-script',
+            'explorexr-model-viewer-loader-manager',
+            'explorexr-model-loader',
+            'explorexr-model-viewer-wrapper',
+        ];
+    }
+
+    public function get_style_depends() {
+        return [ 'explorexr-model-viewer' ];
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Controls                                                            */
+    /* ------------------------------------------------------------------ */
+
+    protected function register_controls() {
+
+        /* ---- Model Selection ----------------------------------------- */
+        $this->start_controls_section(
+            'section_model',
+            [
+                'label' => esc_html__( 'Model', 'explorexr' ),
+                'tab'   => Controls_Manager::TAB_CONTENT,
+            ]
+        );
+
+        // Build a key=>label map from all published ExploreXR models.
+        $model_options = $this->get_model_options();
+
+        if ( ! empty( $model_options ) ) {
+            $this->add_control(
+                'model_id',
+                [
+                    'label'       => esc_html__( 'Select 3D Model', 'explorexr' ),
+                    'type'        => Controls_Manager::SELECT,
+                    'options'     => $model_options,
+                    'default'     => array_key_first( $model_options ),
+                    'description' => esc_html__( 'Choose the 3D model to display. You can manage models under ExploreXR → Browse Models.', 'explorexr' ),
+                ]
+            );
+        } else {
+            $this->add_control(
+                'no_models_notice',
+                [
+                    'type'            => Controls_Manager::RAW_HTML,
+                    'raw'             => sprintf(
+                        /* translators: %s: URL to create model page */
+                        __( 'No 3D models found. <a href="%s" target="_blank">Create your first model</a> in ExploreXR.', 'explorexr' ),
+                        esc_url( admin_url( 'admin.php?page=explorexr-create-model' ) )
+                    ),
+                    'content_classes' => 'elementor-panel-alert elementor-panel-alert-warning',
+                ]
+            );
+        }
+
+        // Manual ID override (useful for large sites or models created after
+        // the widget was added to the page).
+        $this->add_control(
+            'model_id_manual',
+            [
+                'label'       => esc_html__( 'Or enter Model ID manually', 'explorexr' ),
+                'type'        => Controls_Manager::NUMBER,
+                'min'         => 1,
+                'placeholder' => esc_html__( 'e.g. 42', 'explorexr' ),
+                'description' => esc_html__( 'Overrides the dropdown above. Find the ID in ExploreXR → Browse Models.', 'explorexr' ),
+            ]
+        );
+
+        $this->end_controls_section();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Rendering                                                           */
+    /* ------------------------------------------------------------------ */
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+
+        // Manual ID takes precedence over the dropdown.
+        $model_id = ! empty( $settings['model_id_manual'] )
+            ? intval( $settings['model_id_manual'] )
+            : intval( $settings['model_id'] ?? 0 );
+
+        if ( ! $model_id ) {
+            $this->render_placeholder(
+                esc_html__( 'Please select or enter a 3D model ID in the widget settings.', 'explorexr' )
+            );
+            return;
+        }
+
+        // Verify the post exists and is the right type.
+        $post = get_post( $model_id );
+        if ( ! $post || $post->post_type !== 'explorexr_model' || $post->post_status !== 'publish' ) {
+            $this->render_placeholder(
+                sprintf(
+                    /* translators: %d: model ID */
+                    esc_html__( 'Model ID %d not found or not published.', 'explorexr' ),
+                    $model_id
+                )
+            );
+            return;
+        }
+
+        // In Elementor's editor preview the shortcode runs inside the iframe
+        // which is a full frontend page load — model-viewer renders normally.
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- do_shortcode output is already escaped by our template
+        echo do_shortcode( '[explorexr_model id="' . $model_id . '"]' );
+    }
+
+    /**
+     * Return a placeholder block when no valid model is selected.
+     * Only shown inside the Elementor editor – never on the frontend.
+     *
+     * @param string $message Human-readable reason.
+     */
+    private function render_placeholder( $message ) {
+        if ( ! \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
+            return; // Silent on frontend.
+        }
+        printf(
+            '<div style="padding:20px;background:#f0f0f0;border:2px dashed #ccc;text-align:center;color:#555;">
+                <span class="dashicons dashicons-format-image" style="font-size:32px;display:block;margin-bottom:8px;"></span>
+                <strong>ExploreXR 3D Model</strong><br><small>%s</small>
+            </div>',
+            esc_html( $message )
+        );
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Helpers                                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Return an array of [ post_id => 'Title (ID: X)' ] for all published models.
+     *
+     * @return array
+     */
+    private function get_model_options() {
+        $models = get_posts( [
+            'post_type'      => 'explorexr_model',
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+        ] );
+
+        $options = [];
+        foreach ( $models as $model ) {
+            /* translators: 1: model title  2: post ID */
+            $options[ $model->ID ] = sprintf( '%s (ID: %d)', $model->post_title, $model->ID );
+        }
+
+        return $options;
+    }
+}

--- a/explorexr/includes/integrations/elementor/class-elementor-widget.php
+++ b/explorexr/includes/integrations/elementor/class-elementor-widget.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * ExploreXR – Elementor Widget
+ *
+ * Registers a native Elementor widget that renders a 3D model using the
+ * [explorexr_model] shortcode.  Because Elementor's preview pane is a full
+ * frontend iframe, the model-viewer custom element is loaded normally and the
+ * 3D model appears live inside the Elementor editor.
+ *
+ * @package ExploreXR
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register the widget once Elementor's widget manager is ready.
+ */
+add_action( 'elementor/widgets/register', 'explorexr_register_elementor_widget' );
+
+function explorexr_register_elementor_widget( $widgets_manager ) {
+    // Guard: only load if the base class exists.
+    if ( ! class_exists( '\Elementor\Widget_Base' ) ) {
+        return;
+    }
+
+    require_once __DIR__ . '/class-elementor-widget-inner.php';
+    $widgets_manager->register( new \ExploreXR\Integrations\Elementor\Widget_3D_Model() );
+}

--- a/explorexr/includes/integrations/index.php
+++ b/explorexr/includes/integrations/index.php
@@ -1,12 +1,71 @@
 <?php
-// Exit if accessed directly
-if (!defined('ABSPATH')) {
+/**
+ * ExploreXR – Page Builder Integrations Bootstrap
+ *
+ * Loads the appropriate page-builder integration only when the
+ * corresponding builder is active, keeping the free version lean.
+ *
+ * Supported builders:
+ *  - Elementor  (widget via elementor/widgets/register)
+ *  - Divi       (module via et_builder_ready)
+ *  - Avada Fusion Builder (element via fusion_builder_before_init)
+ *
+ * @package ExploreXR
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// Silence is golden.
+/* ---- Elementor ---------------------------------------------------------- */
+// Load only when Elementor is active; the file itself hooks to
+// 'elementor/widgets/register' so there is no risk of early class loading.
+if ( did_action( 'elementor/loaded' ) || function_exists( 'elementor_load_plugin_textdomain' ) ) {
+    $elementor_widget = EXPLOREXR_PLUGIN_DIR . 'includes/integrations/elementor/class-elementor-widget.php';
+    if ( file_exists( $elementor_widget ) ) {
+        require_once $elementor_widget;
+    }
+} else {
+    // Defer until plugins_loaded in case Elementor loads after us.
+    add_action( 'plugins_loaded', function () {
+        if ( did_action( 'elementor/loaded' ) || function_exists( 'elementor_load_plugin_textdomain' ) ) {
+            $elementor_widget = EXPLOREXR_PLUGIN_DIR . 'includes/integrations/elementor/class-elementor-widget.php';
+            if ( file_exists( $elementor_widget ) ) {
+                require_once $elementor_widget;
+            }
+        }
+    }, 20 );
+}
 
+/* ---- Divi Builder ------------------------------------------------------- */
+// Divi sets 'ET_BUILDER_PLUGIN_ACTIVE' or defines the ET_Builder_Module class.
+// We load on plugins_loaded (priority 20) so Divi has had time to initialise.
+add_action( 'plugins_loaded', function () {
+    if (
+        defined( 'ET_BUILDER_PLUGIN_ACTIVE' ) ||
+        defined( 'ET_CORE_VERSION' ) ||
+        class_exists( 'ET_Builder_Module' )
+    ) {
+        $divi_module = EXPLOREXR_PLUGIN_DIR . 'includes/integrations/divi/class-divi-module.php';
+        if ( file_exists( $divi_module ) ) {
+            require_once $divi_module;
+        }
+    }
+}, 20 );
 
-
-
-
+/* ---- Avada Fusion Builder ----------------------------------------------- */
+// Fusion Builder defines the 'FusionBuilder' class or the
+// 'fusion_builder_before_init' action.
+add_action( 'plugins_loaded', function () {
+    if (
+        class_exists( 'FusionBuilder' ) ||
+        class_exists( 'Fusion_Builder_Element' ) ||
+        defined( 'FUSION_BUILDER_VERSION' )
+    ) {
+        $avada_element = EXPLOREXR_PLUGIN_DIR . 'includes/integrations/avada/class-fusion-element.php';
+        if ( file_exists( $avada_element ) ) {
+            require_once $avada_element;
+        }
+    }
+}, 20 );


### PR DESCRIPTION
## Summary
This PR adds native integration support for three major WordPress page builders: Elementor, Divi, and Avada Fusion Builder. Users can now drag-and-drop 3D model widgets/modules directly into their page layouts and see live previews in the builder's editor.

## Key Changes

- **Elementor Widget** (`class-elementor-widget.php` + `class-elementor-widget-inner.php`)
  - Registers a native Elementor widget that renders 3D models via the `[explorexr_model]` shortcode
  - Includes model selection dropdown with all published models
  - Supports manual model ID entry as override
  - Displays helpful placeholders in editor when no model is selected
  - Declares required script/style dependencies for proper loading in preview iframe

- **Divi Builder Module** (`class-divi-module.php`)
  - Registers a custom Divi module with model selection controls
  - Renders shortcode in Divi's Visual Builder preview
  - Includes dropdown selector and manual ID input field
  - Provides user-friendly error messages for missing/unpublished models

- **Avada Fusion Builder Element** (`class-fusion-element.php`)
  - Registers a Fusion Builder element for Avada theme
  - Implements element UI with model dropdown and manual ID override
  - Renders via shortcode with server-side HTML streaming to preview

- **Integration Bootstrap** (`includes/integrations/index.php`)
  - Conditionally loads builder integrations only when the corresponding builder is active
  - Uses action hooks and capability checks to avoid unnecessary loading
  - Defers Elementor loading to `plugins_loaded` to handle late initialization

- **Main Plugin File** (`explorexr.php`)
  - Updated to load the integrations bootstrap file
  - Enables page builder support in the free version

- **Search Enhancement** (`browse-models.js` + `modern-model-browser.php`)
  - Model search now supports both title text and model ID matching
  - Updated placeholder text to indicate ID search capability
  - Improved search logic with trim and partial ID matching

## Implementation Details

- All builder integrations follow the same pattern: model selection dropdown + manual ID override
- Each integration validates that the selected model exists, is published, and is the correct post type
- Integrations leverage the existing `[explorexr_model]` shortcode for rendering, ensuring consistency
- Conditional loading prevents unnecessary code execution when builders are not active
- All user-facing strings are properly internationalized with `esc_html__()` and similar functions

https://claude.ai/code/session_01AA3YMjL7og3yPGnqDjmCDg