### PR TITLE
Fix bugs, remove legacy code, optimize performance, harden addon enforcement

### DIFF
--- a/explorexr/admin/ajax/ajax-handlers.php
+++ b/explorexr/admin/ajax/ajax-handlers.php
@@ -72,7 +72,7 @@ add_action('wp_ajax_explorexr_delete_model', 'explorexr_ajax_delete_model');
 /**
  * Direct download + activate a free addon from update.expoxr.com.
  *
- * Free version: whitelist limited to AR, Animation, Loading, Annotations.
+ * Free version: whitelist limited to AR, Animation, Loading.
  * Enforces one-addon-at-a-time before install.
  */
 function explorexr_free_ajax_direct_download_addon() {
@@ -135,7 +135,13 @@ function explorexr_free_ajax_direct_download_addon() {
         wp_send_json_error(array('message' => esc_html__('No download URL in server response.', 'explorexr')));
     }
 
-    $download_url = esc_url_raw($meta['download_url']);
+    $download_url  = esc_url_raw($meta['download_url']);
+    $allowed_hosts = array('update.expoxr.com', 'downloads.expoxr.com');
+    $url_host      = wp_parse_url($download_url, PHP_URL_HOST);
+    if (!in_array($url_host, $allowed_hosts, true)) {
+        wp_send_json_error(array('message' => esc_html__('Download URL is not from a trusted source.', 'explorexr')));
+        return;
+    }
 
     require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
     require_once ABSPATH . 'wp-admin/includes/plugin-install.php';

--- a/explorexr/admin/pages/create-model-page.php
+++ b/explorexr/admin/pages/create-model-page.php
@@ -83,7 +83,7 @@ function explorexr_handle_model_creation() {
         $model_source = isset($_POST['model_source']) ? sanitize_text_field(wp_unslash($_POST['model_source'])) : 'upload';
         
         // Load size validator for validation
-        require_once EXPLOREXR_PREMIUM_PLUGIN_DIR . 'includes/utils/size-validator.php';
+        require_once EXPLOREXR_PLUGIN_DIR . 'includes/utils/size-validator.php';
         
         // Validate and save model viewer size settings
         $width_input = isset($_POST['viewer_width']) ? sanitize_text_field(wp_unslash($_POST['viewer_width'])) : '100vw';
@@ -265,17 +265,17 @@ function explorexr_create_model_page() {
     // Enqueue validation and preview scripts
     wp_enqueue_script(
         'explorexr-size-validation',
-        EXPLOREXR_PREMIUM_PLUGIN_URL . 'admin/js/size-validation.js',
+        EXPLOREXR_PLUGIN_URL . 'admin/js/size-validation.js',
         array('jquery'),
-        EXPLOREXR_PREMIUM_VERSION,
+        EXPLOREXR_VERSION,
         true
     );
     
     wp_enqueue_script(
         'explorexr-size-preview-indicator',
-        EXPLOREXR_PREMIUM_PLUGIN_URL . 'admin/js/size-preview-indicator.js',
+        EXPLOREXR_PLUGIN_URL . 'admin/js/size-preview-indicator.js',
         array('jquery'),
-        EXPLOREXR_PREMIUM_VERSION,
+        EXPLOREXR_VERSION,
         true
     );
     

--- a/explorexr/admin/pages/edit-model-page.php
+++ b/explorexr/admin/pages/edit-model-page.php
@@ -88,25 +88,25 @@ function ExploreXR_edit_model_page() {
     // Enqueue size validation and preview scripts
     wp_enqueue_script(
         'explorexr-size-validation',
-        EXPLOREXR_PREMIUM_PLUGIN_URL . 'admin/js/size-validation.js',
+        EXPLOREXR_PLUGIN_URL . 'admin/js/size-validation.js',
         array('jquery'),
-        EXPLOREXR_PREMIUM_VERSION,
+        EXPLOREXR_VERSION,
         true
     );
     
     wp_enqueue_script(
         'explorexr-preview-size-sync',
-        EXPLOREXR_PREMIUM_PLUGIN_URL . 'admin/js/preview-size-sync.js',
+        EXPLOREXR_PLUGIN_URL . 'admin/js/preview-size-sync.js',
         array('jquery'),
-        EXPLOREXR_PREMIUM_VERSION,
+        EXPLOREXR_VERSION,
         true
     );
     
     wp_enqueue_script(
         'explorexr-size-preview-indicator',
-        EXPLOREXR_PREMIUM_PLUGIN_URL . 'admin/js/size-preview-indicator.js',
+        EXPLOREXR_PLUGIN_URL . 'admin/js/size-preview-indicator.js',
         array('jquery'),
-        EXPLOREXR_PREMIUM_VERSION,
+        EXPLOREXR_VERSION,
         true
     );
     
@@ -209,7 +209,7 @@ function ExploreXR_edit_model_page() {
     }
     
     // Load size validator class for validation
-    require_once EXPLOREXR_PREMIUM_PLUGIN_DIR . 'includes/utils/size-validator.php';
+    require_once EXPLOREXR_PLUGIN_DIR . 'includes/utils/size-validator.php';
     
     // Handle form submission
     if (isset($_POST['ExploreXR_edit_model_submit']) && check_admin_referer('explorexr_edit_model', 'explorexr_edit_nonce')) {

--- a/explorexr/explorexr.php
+++ b/explorexr/explorexr.php
@@ -231,13 +231,17 @@ function explorexr_free_preload_decoder_assets() {
         return;
     }
 
-    $draco_wasm = EXPLOREXR_PLUGIN_DIR . 'assets/vendor/draco/draco_decoder.wasm';
-    $basis_wasm = EXPLOREXR_PLUGIN_DIR . 'assets/vendor/basis-universal/basis_transcoder.wasm';
+    static $draco_exists = null;
+    static $basis_exists = null;
+    if ($draco_exists === null) {
+        $draco_exists = file_exists(EXPLOREXR_PLUGIN_DIR . 'assets/vendor/draco/draco_decoder.wasm');
+        $basis_exists = file_exists(EXPLOREXR_PLUGIN_DIR . 'assets/vendor/basis-universal/basis_transcoder.wasm');
+    }
 
-    if (file_exists($draco_wasm)) {
+    if ($draco_exists) {
         echo '<link rel="preload" href="' . esc_url(EXPLOREXR_PLUGIN_URL . 'assets/vendor/draco/draco_decoder.wasm') . '" as="fetch" crossorigin>' . "\n";
     }
-    if (file_exists($basis_wasm)) {
+    if ($basis_exists) {
         echo '<link rel="preload" href="' . esc_url(EXPLOREXR_PLUGIN_URL . 'assets/vendor/basis-universal/basis_transcoder.wasm') . '" as="fetch" crossorigin>' . "\n";
     }
 }
@@ -296,11 +300,7 @@ function explorexr_free_admin_enqueue_scripts($hook) {
         'nonce'     => wp_create_nonce('explorexr_admin_nonce'),
         'isPremium' => false,
         'version'   => EXPLOREXR_VERSION,
-    ));
-    wp_localize_script('explorexr-admin', 'ExploreXRAdminVars', array(
         'pluginUrl' => EXPLOREXR_PLUGIN_URL,
-        'ajaxUrl'   => admin_url('admin-ajax.php'),
-        'nonce'     => wp_create_nonce('explorexr_admin_nonce'),
     ));
 }
 add_action('admin_enqueue_scripts', 'explorexr_free_admin_enqueue_scripts');

--- a/explorexr/includes/addons/free-addon-manager.php
+++ b/explorexr/includes/addons/free-addon-manager.php
@@ -251,10 +251,16 @@ class ExploreXR_Addon_Manager {
      * (e.g. WP-CLI bypass), deactivate the extras keeping only one.
      */
     public function enforce_single_addon() {
+        if (!function_exists('is_plugin_active')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+        // Use direct WordPress plugin state so WP-CLI activations that run before
+        // an addon's plugins_loaded self-registration are still detected.
         $active = array();
         foreach (self::WHITELIST as $slug) {
-            if ($this->is_addon_active($slug)) {
-                $active[$slug] = $this->registered_addons[$slug]['file'];
+            $plugin_file = "explorexr-{$slug}-addon/explorexr-{$slug}-addon.php";
+            if (is_plugin_active($plugin_file)) {
+                $active[$slug] = $plugin_file;
             }
         }
         if (count($active) <= self::MAX_ACTIVE) {
@@ -270,7 +276,7 @@ class ExploreXR_Addon_Manager {
                 $kept = true;
                 continue;
             }
-            deactivate_plugins(plugin_basename($file), true);
+            deactivate_plugins($file, true);
         }
         set_transient(self::ERROR_TRANSIENT, __('ExploreXR Free only allows a single addon. Extra addons have been deactivated.', 'explorexr'), self::NOTICE_TTL);
     }

--- a/explorexr/includes/core/helper-functions.php
+++ b/explorexr/includes/core/helper-functions.php
@@ -95,7 +95,9 @@ if (!function_exists('explorexr_premium_has_model_viewers')) {
             if (is_404() || is_category() || is_tag() || is_archive() || is_search()) {
                 return false;
             }
-            return true;
+            // Only load assets on singular-type pages or recognized front-page contexts.
+            // Avoids loading model-viewer scripts on listing pages, REST requests, etc.
+            return is_singular() || is_front_page() || is_home();
         }
 
         if ($post->post_type === 'explorexr_model') {

--- a/explorexr/includes/core/shortcodes.php
+++ b/explorexr/includes/core/shortcodes.php
@@ -42,11 +42,6 @@ function explorexr_premium_convert_percent_to_viewport($value, $dimension = 'wid
     return $value;
 }
 
-// Enqueue model loader script when needed
-function EXPLOREXR_enqueue_model_loader() {
-    wp_enqueue_script('explorexr-model-loader', EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/js/model-loader.js', array(), EXPLOREXR_PREMIUM_VERSION, true);
-}
-
 // Helper function to build model-viewer attributes
 function EXPLOREXR_build_model_attributes($model_id, $model_file, $alt_text, $width, $height, $model_poster = '') {
     // Basic attributes - DO NOT add width/height here (applied to wrapper container instead)
@@ -289,6 +284,10 @@ add_shortcode('explorexr_model', function ($atts) {
         return 'Invalid model ID.';
     }
 
+    // Prime the post meta cache so all subsequent get_post_meta() calls in this
+    // shortcode and in EXPLOREXR_build_model_attributes() hit the cache, not the DB.
+    update_post_meta_cache(array($model_id));
+
     $model_file = get_post_meta($model_id, '_explorexr_model_file', true) ?: '';
     if (!$model_file) {
         return ' ExploreXR Alert: Model not found. Possibly abducted by polygons from another dimension.';
@@ -302,7 +301,6 @@ add_shortcode('explorexr_model', function ($atts) {
     
     // Get poster image if available
     $model_poster = get_post_meta($model_id, '_explorexr_model_poster', true) ?: '';
-    $model_poster_id = get_post_meta($model_id, '_explorexr_model_poster_id', true) ?: '';
 
     // Get size settings
     $viewer_size = get_post_meta($model_id, '_explorexr_viewer_size', true) ?: '';
@@ -417,28 +415,22 @@ add_shortcode('explorexr_model', function ($atts) {
         $responsive_css_content .= '}';
     }
     
-    // Use wp_add_inline_style for proper page builder compatibility
+    // Enqueue base style before adding inline CSS so wp_add_inline_style has a parent.
+    wp_enqueue_style('explorexr-model-viewer', EXPLOREXR_PLUGIN_URL . 'assets/css/model-viewer.css', array(), EXPLOREXR_VERSION);
+
     if (!empty($responsive_css_content)) {
-        // Create unique style handle per model instance
-        $style_handle = 'explorexr-model-' . $model_id;
-        
-        // Ensure base model-viewer style is registered/enqueued
-        if (!wp_style_is('explorexr-model-viewer', 'enqueued')) {
-            wp_enqueue_style('explorexr-model-viewer', EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/model-viewer.css', array(), EXPLOREXR_PREMIUM_VERSION);
-        }
-        
-        // Add inline styles to the base handle
         wp_add_inline_style('explorexr-model-viewer', $responsive_css_content);
     }
-    
+
     // Annotations are not available in the free version
     $annotations = null;
-    
-    // Enqueue required scripts and styles
-    wp_enqueue_style('explorexr-model-viewer', EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/model-viewer.css', array(), EXPLOREXR_PREMIUM_VERSION);
 
-    // Trigger model-viewer script registration (addons handle their own assets)
-    include EXPLOREXR_PLUGIN_DIR . 'template-parts/model-viewer-script.php';
+    // Trigger model-viewer script registration — run once per page regardless of model count.
+    static $scripts_registered = false;
+    if (!$scripts_registered) {
+        include EXPLOREXR_PLUGIN_DIR . 'template-parts/model-viewer-script.php';
+        $scripts_registered = true;
+    }
     
     // Check if the model is a large file that needs special handling
     $large_model_handling = get_option('explorexr_large_model_handling', 'direct');
@@ -496,7 +488,7 @@ add_shortcode('explorexr_model', function ($atts) {
         $model_instance_id = 'explorexr-model-' . $model_id . '-' . uniqid();
         
         // Enqueue the model loader script
-        EXPLOREXR_enqueue_model_loader();
+        wp_enqueue_script('explorexr-model-loader', EXPLOREXR_PLUGIN_URL . 'assets/js/model-loader.js', array(), EXPLOREXR_VERSION, true);
         
         // Build model attributes using our helper function
         $model_attributes = EXPLOREXR_build_model_attributes($model_id, $model_file, $alt_text, $width, $height, $model_poster);
@@ -529,7 +521,7 @@ add_shortcode('explorexr_model', function ($atts) {
         $model_instance_id = 'explorexr-model-' . $model_id . '-' . uniqid();
         
         // Enqueue the lazy loader script
-        wp_enqueue_script('explorexr-lazy-loader', EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/js/lazy-loader.js', array(), EXPLOREXR_PREMIUM_VERSION, true);
+        wp_enqueue_script('explorexr-lazy-loader', EXPLOREXR_PLUGIN_URL . 'assets/js/lazy-loader.js', array(), EXPLOREXR_VERSION, true);
         
         // Build model attributes using our helper function
         $model_attributes = EXPLOREXR_build_model_attributes($model_id, $model_file, $alt_text, $width, $height, $model_poster);
@@ -594,14 +586,6 @@ add_shortcode('EXPLOREXR_model', function ($atts) {
     return do_shortcode('[explorexr_model id="' . (isset($atts['id']) ? $atts['id'] : '') . '"]');
 });
 
-// Enqueue admin scripts
-add_action('admin_enqueue_scripts', function ($hook) {
-    // Add null check to prevent deprecated warning in PHP 8.1+
-    if (!empty($hook) && is_string($hook) && strpos($hook, 'explorexr') !== false) {
-        // Add the script directly in admin
-        wp_enqueue_script('explorexr-model-loader', EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/js/model-loader.js', array('jquery'), EXPLOREXR_PREMIUM_VERSION, true);
-    }
-});
 
 /**
  * FIX 3: Shared renderer function for admin previews
@@ -621,7 +605,7 @@ function explorexr_render_model_viewer($model_id, $context = 'admin', $overrides
         return '<div class="explorexr-error">Model file not found</div>';
     }
     
-    $alt_text = get_post_meta($model_id, '_explorexr_alt_text', true) ?: get_the_title($model_id);
+    $alt_text = get_post_meta($model_id, '_explorexr_model_alt_text', true) ?: get_the_title($model_id);
     $model_poster = get_post_meta($model_id, '_explorexr_model_poster', true) ?: '';
     
     // Default dimensions for admin previews
@@ -647,17 +631,7 @@ function explorexr_render_model_viewer($model_id, $context = 'admin', $overrides
         $attributes['camera-controls'] = ''; // Boolean attribute
     }
     
-    // Generate HTML
-    $html = '<model-viewer';
-    foreach ($attributes as $key => $value) {
-        if ($value === '' && in_array($key, ['camera-controls', 'autoplay', 'loop', 'auto-rotate'], true)) {
-            // Boolean attributes
-            $html .= ' ' . esc_attr($key);
-        } else {
-            $html .= ' ' . esc_attr($key) . '="' . esc_attr($value) . '"';
-        }
-    }
-    $html .= '></model-viewer>';
+    $html = '<model-viewer' . EXPLOREXR_generate_attributes_html($attributes) . '></model-viewer>';
     
     return $html;
 }

--- a/explorexr/includes/integrations/beaver-builder/class-beaver-builder-module.php
+++ b/explorexr/includes/integrations/beaver-builder/class-beaver-builder-module.php
@@ -27,7 +27,7 @@ class ExploreXR_Beaver_Builder_Module extends FLBuilderModule {
             'category'      => esc_html__( 'Media', 'explorexr' ),
             'icon'          => 'format-gallery.svg',
             'dir'           => __DIR__ . '/',
-            'url'           => EXPLOREXR_PREMIUM_PLUGIN_URL . 'includes/integrations/beaver-builder/',
+            'url'           => EXPLOREXR_PLUGIN_URL . 'includes/integrations/beaver-builder/',
         ) );
     }
 
@@ -37,17 +37,17 @@ class ExploreXR_Beaver_Builder_Module extends FLBuilderModule {
     public function enqueue_scripts() {
         wp_enqueue_style(
             'explorexr-model-viewer',
-            EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/model-viewer.css',
+            EXPLOREXR_PLUGIN_URL . 'assets/css/model-viewer.css',
             array(),
-            EXPLOREXR_PREMIUM_VERSION
+            EXPLOREXR_VERSION
         );
 
         if ( ! wp_script_is( 'explorexr-model-loader', 'registered' ) ) {
             wp_register_script(
                 'explorexr-model-loader',
-                EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/js/model-loader.js',
+                EXPLOREXR_PLUGIN_URL . 'assets/js/model-loader.js',
                 array( 'jquery' ),
-                EXPLOREXR_PREMIUM_VERSION,
+                EXPLOREXR_VERSION,
                 true
             );
         }

--- a/explorexr/includes/integrations/divi/class-divi-integration.php
+++ b/explorexr/includes/integrations/divi/class-divi-integration.php
@@ -45,17 +45,17 @@ class ExploreXR_Divi_Integration {
     public static function builder_assets() {
         wp_enqueue_style(
             'explorexr-model-viewer',
-            EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/model-viewer.css',
+            EXPLOREXR_PLUGIN_URL . 'assets/css/model-viewer.css',
             array(),
-            EXPLOREXR_PREMIUM_VERSION
+            EXPLOREXR_VERSION
         );
 
         if ( ! wp_script_is( 'explorexr-model-loader', 'registered' ) ) {
             wp_register_script(
                 'explorexr-model-loader',
-                EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/js/model-loader.js',
+                EXPLOREXR_PLUGIN_URL . 'assets/js/model-loader.js',
                 array( 'jquery' ),
-                EXPLOREXR_PREMIUM_VERSION,
+                EXPLOREXR_VERSION,
                 true
             );
         }

--- a/explorexr/includes/integrations/elementor/class-elementor-integration.php
+++ b/explorexr/includes/integrations/elementor/class-elementor-integration.php
@@ -69,9 +69,9 @@ class ExploreXR_Elementor_Integration {
     public static function editor_styles() {
         wp_enqueue_style(
             'explorexr-elementor-editor',
-            EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/elementor-editor.css',
+            EXPLOREXR_PLUGIN_URL . 'assets/css/elementor-editor.css',
             array(),
-            EXPLOREXR_PREMIUM_VERSION
+            EXPLOREXR_VERSION
         );
     }
 
@@ -83,18 +83,18 @@ class ExploreXR_Elementor_Integration {
         // Core model-viewer CSS.
         wp_enqueue_style(
             'explorexr-model-viewer',
-            EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/model-viewer.css',
+            EXPLOREXR_PLUGIN_URL . 'assets/css/model-viewer.css',
             array(),
-            EXPLOREXR_PREMIUM_VERSION
+            EXPLOREXR_VERSION
         );
 
         // Register the model-loader so the shortcode can enqueue it.
         if ( ! wp_script_is( 'explorexr-model-loader', 'registered' ) ) {
             wp_register_script(
                 'explorexr-model-loader',
-                EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/js/model-loader.js',
+                EXPLOREXR_PLUGIN_URL . 'assets/js/model-loader.js',
                 array( 'jquery' ),
-                EXPLOREXR_PREMIUM_VERSION,
+                EXPLOREXR_VERSION,
                 true
             );
         }

--- a/explorexr/includes/integrations/gutenberg/class-gutenberg-integration.php
+++ b/explorexr/includes/integrations/gutenberg/class-gutenberg-integration.php
@@ -40,9 +40,9 @@ class ExploreXR_Gutenberg_Integration {
         // Register the editor script.
         wp_register_script(
             'explorexr-gutenberg-block',
-            EXPLOREXR_PREMIUM_PLUGIN_URL . 'includes/integrations/gutenberg/block.js',
+            EXPLOREXR_PLUGIN_URL . 'includes/integrations/gutenberg/block.js',
             array( 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-server-side-render', 'wp-data' ),
-            EXPLOREXR_PREMIUM_VERSION,
+            EXPLOREXR_VERSION,
             false
         );
 
@@ -55,9 +55,9 @@ class ExploreXR_Gutenberg_Integration {
         // Register the editor style.
         wp_register_style(
             'explorexr-gutenberg-editor',
-            EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/elementor-editor.css',
+            EXPLOREXR_PLUGIN_URL . 'assets/css/elementor-editor.css',
             array(),
-            EXPLOREXR_PREMIUM_VERSION
+            EXPLOREXR_VERSION
         );
 
         register_block_type( 'explorexr/3d-model', array(

--- a/explorexr/includes/integrations/wpbakery/class-wpbakery-integration.php
+++ b/explorexr/includes/integrations/wpbakery/class-wpbakery-integration.php
@@ -40,7 +40,7 @@ class ExploreXR_WPBakery_Integration {
         vc_map( array(
             'name'        => esc_html__( 'ExploreXR 3D Model', 'explorexr' ),
             'base'        => 'explorexr_model',
-            'icon'        => EXPLOREXR_PREMIUM_PLUGIN_URL . 'assets/css/elementor-editor.css', // fallback icon
+            'icon'        => EXPLOREXR_PLUGIN_URL . 'assets/css/elementor-editor.css', // fallback icon
             'category'    => esc_html__( 'ExploreXR', 'explorexr' ),
             'description' => esc_html__( 'Display an interactive 3D model.', 'explorexr' ),
             'params'      => array(

--- a/explorexr/includes/ui/model-viewer-renderer.php
+++ b/explorexr/includes/ui/model-viewer-renderer.php
@@ -32,12 +32,12 @@ function explorexr_premium_render_model_viewer($model_id, $custom_attrs = array(
     
     // Default attributes
     $default_attrs = array(
-        'src' => esc_url($model_file),
-        'alt' => get_the_title($model_id) . ' 3D Model',
-        'camera-controls' => 'true',
-        'class' => 'explorexr-model-viewer',
+        'src'             => esc_url($model_file),
+        'alt'             => get_the_title($model_id) . ' 3D Model',
+        'camera-controls' => '',
+        'class'           => 'explorexr-model-viewer',
         // Ensure visibility even if parent lacks height; width stays fluid, height fixed
-        'style' => 'width:100%;height:520px;background:#f5f5f5;'
+        'style'           => 'width:100%;height:520px;background:#f5f5f5;'
     );
     
     // Merge custom attributes with defaults

--- a/explorexr/template-parts/model-viewer-script.php
+++ b/explorexr/template-parts/model-viewer-script.php
@@ -31,20 +31,35 @@ if (!defined('EXPLOREXR_VERSION')) {
     define('EXPLOREXR_VERSION', '1.0.0');
 }
 
-// Get settings from options
-// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variables for script configuration
-// Force local mode for WordPress.org compliance - always use local (CDN disabled)
-// Note: Option migration to 'local' is handled in admin_init hook, not during render
-$cdn_source = 'local';
-$model_viewer_version = get_option('explorexr_model_viewer_version', '4.1.0');
+// Static once-per-page guard: all script/style registration runs exactly once.
+// On pages with multiple [explorexr_model] shortcodes the include fires N times;
+// this prevents duplicate wp_enqueue_*/wp_localize_script calls on those pages.
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template static flag
+static $explorexr_scripts_initialized = false;
+if ($explorexr_scripts_initialized) {
+    return;
+}
+$explorexr_scripts_initialized = true;
 
-// Get the new loading options
-$script_location = get_option('explorexr_script_location', 'footer');
-$script_loading_timing = get_option('explorexr_script_loading_timing', 'auto');
-$lazy_load_poster = get_option('explorexr_lazy_load_poster', false);
+// Cache all per-request options in a static so repeated shortcode calls never
+// re-query the DB or alloptions cache more than once per page load.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variables for script configuration
+static $mv_cached_opts = null;
+if ($mv_cached_opts === null) {
+    $mv_cached_opts = array(
+        'model_viewer_version'  => get_option('explorexr_model_viewer_version', '4.1.0'),
+        'script_location'       => get_option('explorexr_script_location', 'footer'),
+        'script_loading_timing' => get_option('explorexr_script_loading_timing', 'auto'),
+        'lazy_load_poster'      => get_option('explorexr_lazy_load_poster', false),
+    );
+}
+$model_viewer_version  = $mv_cached_opts['model_viewer_version'];
+$script_location       = $mv_cached_opts['script_location'];
+$script_loading_timing = $mv_cached_opts['script_loading_timing'];
+$lazy_load_poster      = $mv_cached_opts['lazy_load_poster'];
 
 // Determine script loading settings
-$load_in_footer = ($script_location === 'footer');
+$load_in_footer    = ($script_location === 'footer');
 $script_attributes = array();
 // Ensure the plugin URL is available before any model-viewer script executes
 $plugin_url_inline_script = 'window.explorexrPluginUrl = window.explorexrPluginUrl || "' . esc_js(EXPLOREXR_PLUGIN_URL) . '";';
@@ -62,50 +77,47 @@ if ($script_loading_timing === 'defer') {
     add_action('wp_footer', 'explorexr_add_ondemand_script_loader');
 }
 
-// Check if script has already been enqueued to prevent duplicates
-// First check if the global registration from admin/core/functions.php exists
+// Cache file-existence checks — these filesystem syscalls would otherwise run on
+// every shortcode call on a page; with statics they run exactly once per request.
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template static file-existence cache
+static $umd_exists = null;
+static $min_exists = null;
+if ($umd_exists === null) {
+    $local_umd_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer-umd.js';
+    $local_min_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer.min.js';
+    $umd_exists     = file_exists($local_umd_path);
+    $min_exists     = file_exists($local_min_path);
+} else {
+    $local_umd_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer-umd.js';
+    $local_min_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer.min.js';
+}
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+
+// Check if script has already been enqueued to prevent duplicates.
+// First check if the global registration from admin/core/functions.php exists.
 if (wp_script_is('explorexr-premium-model-viewer', 'registered') || wp_script_is('explorexr-premium-model-viewer', 'enqueued')) {
-    // Global registration exists, just enqueue it (don't re-register)
     if (!wp_script_is('explorexr-premium-model-viewer', 'enqueued')) {
         wp_enqueue_script('explorexr-premium-model-viewer');
     }
-    // Ensure model-viewer picks up the correct plugin URL before execution
     wp_add_inline_script('explorexr-premium-model-viewer', $plugin_url_inline_script, 'before');
 } else {
-    // Fallback: Use template's own registration (legacy support)
+    // Fallback: Use template's own registration (legacy support).
     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script handle
     $script_handle = 'model-viewer-script';
     if (!wp_script_is($script_handle, 'enqueued')) {
-    if ($cdn_source === 'local') {
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for file path check
-        $local_umd_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer-umd.js';
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for file path check
-        $local_min_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer.min.js';
-        
-        // If UMD version exists, use it (preferred for compatibility)
-        if (file_exists($local_umd_path)) {
+        if ($umd_exists) {
             wp_enqueue_script($script_handle, EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer-umd.js', array(), $model_viewer_version, $load_in_footer);
-            
-            // Apply script attributes if needed
             if (!empty($script_attributes)) {
                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Loop variables in template
                 foreach ($script_attributes as $attr_name => $attr_value) {
                     wp_script_add_data($script_handle, $attr_name, $attr_value);
                 }
             }
-        }
-        // If only the minified version exists, use it properly as a module
-        elseif (file_exists($local_min_path)) {
-            // Register the script properly with WordPress
+        } elseif ($min_exists) {
             wp_register_script($script_handle, EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer.min.js', array(), $model_viewer_version, $load_in_footer);
             wp_enqueue_script($script_handle);
-            
-            // Add module attribute for ES6 modules
             wp_script_add_data($script_handle, 'type', 'module');
-        }
-        // If no local versions exist, show admin error and don't load any script
-        else {
-            // Add admin notice about missing local files
+        } else {
             if (is_admin() && current_user_can('manage_options')) {
                 add_action('admin_notices', function() use ($local_umd_path, $local_min_path) {
                     echo '<div class="notice notice-error is-dismissible">';
@@ -114,29 +126,9 @@ if (wp_script_is('explorexr-premium-model-viewer', 'registered') || wp_script_is
                     echo '</div>';
                 });
             }
-            
-            return; // Exit without loading any script
+            return;
         }
-    } else {
-        // WordPress.org Plugin Check compliance: External CDN resources are not allowed
-        // All scripts must be bundled locally with the plugin
-        
-        // Add admin notice about CDN source being disabled
-        if (is_admin() && current_user_can('manage_options')) {
-            add_action('admin_notices', function() {
-                echo '<div class="notice notice-error is-dismissible">';
-                echo '<p><strong>ExploreXR Error:</strong> CDN source is not allowed. WordPress.org Plugin Check requires all scripts to be bundled locally.</p>';
-                echo '<p><em>Please set cdn_source to "local" and ensure model-viewer script files exist in assets/js/ directory.</em></p>';
-                echo '</div>';
-            });
-        }
-        
-        
-        return; // Exit without loading any external script
     }
-    } // End fallback registration check
-    
-    // Ensure the plugin URL is defined before the legacy model-viewer script executes
     wp_add_inline_script($script_handle, $plugin_url_inline_script, 'before');
 }
 
@@ -154,29 +146,19 @@ wp_enqueue_script('explorexr-model-viewer-wrapper', EXPLOREXR_PLUGIN_URL . 'asse
 $loading_options = explorexr_get_loading_options();
 wp_localize_script('explorexr-model-viewer-wrapper', 'ExploreXRLoadingOptions', $loading_options);
 
-// Pass script configuration for preloader
+// Pass script configuration for preloader.
+// Use the same static file-existence results from above to avoid redundant syscalls.
 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script configuration
-$script_config = array();
-if ($cdn_source === 'local') {
-    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for file path check
-    $local_umd_path = EXPLOREXR_PLUGIN_DIR . 'assets/js/model-viewer-umd.js';
-    if (file_exists($local_umd_path)) {
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script config
-        $script_config['modelViewerScriptUrl'] = EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer-umd.js';
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script config
-        $script_config['scriptType'] = 'umd';
-    } else {
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script config
-        $script_config['modelViewerScriptUrl'] = EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer.min.js';
-        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script config
-        $script_config['scriptType'] = 'module';
-    }
+if ($umd_exists) {
+    $script_config = array(
+        'modelViewerScriptUrl' => EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer-umd.js',
+        'scriptType'           => 'umd',
+    );
 } else {
-    // Local UMD version for better compatibility (WordPress.org compliance)
-    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script config
-    $script_config['modelViewerScriptUrl'] = EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer-umd.js';
-    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template variable for script config
-    $script_config['scriptType'] = 'umd';
+    $script_config = array(
+        'modelViewerScriptUrl' => EXPLOREXR_PLUGIN_URL . 'assets/js/model-viewer.min.js',
+        'scriptType'           => 'module',
+    );
 }
 
 // Add plugin URL for local dependencies
@@ -283,18 +265,13 @@ if (!function_exists('explorexr_add_model_viewer_attributes')) {    /**
      * @return array Updated attributes
      */
     function explorexr_add_model_viewer_attributes($attributes, $model_id = null) {
-        // Get settings from options
-        $loading_display = get_option('explorexr_loading_display', 'bar');
-        $loading_bar_color = get_option('explorexr_loading_bar_color', '#1e88e5');
-        $loading_bar_size = get_option('explorexr_loading_bar_size', 'medium');
-        $loading_bar_position = get_option('explorexr_loading_bar_position', 'middle');
-        $percentage_font_size = get_option('explorexr_percentage_font_size', 24);
-        $percentage_font_family = get_option('explorexr_percentage_font_family', 'Arial, sans-serif');
-        $percentage_font_color = get_option('explorexr_percentage_font_color', '#333333');
-        $percentage_position = get_option('explorexr_percentage_position', 'center-center');
-        
         // Resolve lazy poster: per-model override wins, otherwise global.
-        $lazy_load_poster = get_option('explorexr_lazy_load_poster', false);
+        // Cached in static so the option is fetched once per page, not per model.
+        static $lazy_load_poster_global = null;
+        if ($lazy_load_poster_global === null) {
+            $lazy_load_poster_global = get_option('explorexr_lazy_load_poster', false);
+        }
+        $lazy_load_poster = $lazy_load_poster_global;
         if (!empty($model_id)) {
             $per_model_lazy_poster = get_post_meta($model_id, '_explorexr_premium_lazy_load_poster', true);
             if ($per_model_lazy_poster === 'on') {
@@ -321,8 +298,11 @@ if (!function_exists('explorexr_add_model_viewer_attributes')) {    /**
         if (defined('EXPLOREXR_PLUGIN_URL')) {
             $attributes['draco-decoder-location']   = EXPLOREXR_PLUGIN_URL . 'assets/vendor/draco/';
             $attributes['ktx2-transcoder-location'] = EXPLOREXR_PLUGIN_URL . 'assets/vendor/basis-universal/';
-            $meshopt_file = EXPLOREXR_PLUGIN_DIR . 'assets/vendor/meshopt/meshopt_decoder.module.js';
-            if (file_exists($meshopt_file)) {
+            static $meshopt_exists = null;
+            if ($meshopt_exists === null) {
+                $meshopt_exists = file_exists(EXPLOREXR_PLUGIN_DIR . 'assets/vendor/meshopt/meshopt_decoder.module.js');
+            }
+            if ($meshopt_exists) {
                 $attributes['meshopt-decoder'] = EXPLOREXR_PLUGIN_URL . 'assets/vendor/meshopt/meshopt_decoder.module.js';
             }
         }


### PR DESCRIPTION
## Summary

This PR addresses four categories of issues found during a senior-level audit of the ExploreXR Free (v1.3.1) codebase:

### 🐛 Bug Fixes
- **Wrong meta key** in `explorexr_render_model_viewer()`: `_explorexr_alt_text` → `_explorexr_model_alt_text` (admin previews were silently rendering with empty alt text)
- **Duplicate CSS enqueue**: `explorexr-model-viewer` style was enqueued twice per shortcode call; restructured so it enqueues once before `wp_add_inline_style`
- **Inconsistent attribute rendering** in `explorexr_render_model_viewer()`: replaced a partial hardcoded boolean-attr list with the existing `EXPLOREXR_generate_attributes_html()`, preventing internal flags (`_container_width`, `no-auto-rotate`, etc.) from leaking into the HTML output
- **Incorrect doc comment** in `ajax-handlers.php` claimed Annotations was a free addon (it is not)
- **Download URL not validated** before addon install: added trusted-domain check (`update.expoxr.com`) so a compromised update server cannot redirect the installer to an arbitrary zip

### Dead / Duplicate Code Removed
- `EXPLOREXR_enqueue_model_loader()` one-liner wrapper — inlined at its single call site
- Dead variable `$model_poster_id` — fetched via `get_post_meta()` but never used
- Dead variable `$style_handle` — created but `wp_add_inline_style` used a hardcoded handle anyway
- Duplicate `admin_enqueue_scripts` hook in `shortcodes.php` — `admin-menu.php` already handles this
- Duplicate `ExploreXRAdminVars` `wp_localize_script` call — merged into `explorexrAdmin` (with `pluginUrl` added)
- Dead CDN `else` branch in `model-viewer-script.php` — `cdn_source` is always `'local'`; unreachable code removed
- 8 dead `get_option()` calls in `explorexr_add_model_viewer_attributes()` — the Loading addon owns these; the comment even said so but the calls remained

### Performance Optimizations
- **`update_post_meta_cache()`** called once at the start of the shortcode callback, priming all meta in a single DB query before the 15+ individual `get_post_meta()` calls that follow
- **Once-per-page static guard** in `model-viewer-script.php` eliminates redundant re-execution when multiple `[explorexr_model]` shortcodes appear on a page — previously `get_option()`, `file_exists()`, `wp_localize_script()`, and `wp_add_inline_script()` all re-ran for every model
- **Static `get_option()` cache** in `explorexr_add_model_viewer_attributes()` — options are per-request constants
- **Static `file_exists()` caches** for UMD, min, and meshopt WASM files — filesystem syscalls now run once per request instead of once per model
- **Tightened `explorexr_premium_has_model_viewers()` fallback** to `is_singular() || is_front_page() || is_home()` — prevents loading model-viewer assets on archive/listing pages, REST requests, etc.

### Addon Enforcement Hardened
- `enforce_single_addon()` now calls `is_plugin_active()` directly instead of relying on `$registered_addons` being populated — catches WP-CLI activations that bypass addon self-registration

### Code Quality
- All `EXPLOREXR_PREMIUM_PLUGIN_URL` / `EXPLOREXR_PREMIUM_VERSION` / `EXPLOREXR_PREMIUM_PLUGIN_DIR` constants replaced with canonical `EXPLOREXR_*` equivalents across `shortcodes.php`, admin pages, and all 5 page builder integration files
- `camera-controls` default value standardized to `''` (HTML boolean attribute) in `model-viewer-renderer.php`

## Test plan

- [ ] Place `[explorexr_model id="N"]` on a post — model loads, responsive CSS applies, no `no-auto-rotate`/`_container_width` attributes in DOM
- [ ] Place 3 shortcodes on a page — model-viewer scripts appear once in source; no duplicate `ExploreXRLoadingOptions` JSON blocks
- [ ] Visit a category/archive page — no `model-viewer.css` or `model-loader.js` in page source
- [ ] Admin browse-models: `<model-viewer alt="...">` shows the correct saved alt text
- [ ] Try activating a second whitelisted addon from WP admin — blocked with error notice
- [ ] `wp plugin activate explorexr-ar-addon explorexr-animation-addon` via WP-CLI — reload admin, second addon auto-deactivated
- [ ] Install an addon from the Addons page — succeeds as before
- [ ] Browser console: `explorexrAdmin.pluginUrl` exists; `ExploreXRAdminVars` is undefined
- [ ] Query Monitor: single `[explorexr_model]` page shows 1 `wp_postmeta` query instead of 15+

https://claude.ai/code/session_01XG6PAtnYyctc6ri4KLXvi5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XG6PAtnYyctc6ri4KLXvi5)_